### PR TITLE
Adding company data on jwt payload

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -36,3 +36,7 @@ services:
         public: false
         tags:
         - { name: 'serializer.normalizer' }
+
+    App\EventListener\AuthenticationSuccessListener:
+        tags:
+            - { name: kernel.event_listener, event: lexik_jwt_authentication.on_authentication_success, method: onAuthenticationSuccessResponse }

--- a/src/EventListener/AuthenticationSuccessListener.php
+++ b/src/EventListener/AuthenticationSuccessListener.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+
+use Lexik\Bundle\JWTAuthenticationBundle\Event\AuthenticationSuccessEvent;
+use Symfony\Component\Security\Core\User\UserInterface;
+
+class AuthenticationSuccessListener
+{
+    public function onAuthenticationSuccessResponse(AuthenticationSuccessEvent $event)
+    {
+        $data = $event->getData();
+        $user = $event->getUser();
+
+        if (!$user instanceof UserInterface) {
+            return;
+        }
+
+        $data['data'] = [
+            'id' => $user->getId(),
+            'name' => $user->getname(),
+            'email' => $user->getEmail(),
+            'logo' => $user->getLogo(),
+        ];
+
+        $event->setData($data);
+    }
+}

--- a/tests/Feature/JWTTest.php
+++ b/tests/Feature/JWTTest.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace App\Tests\Feature;
+
+
+use App\Entity\Company;
+use App\Tests\Support\HasAuthentication;
+use App\Tests\TestCase;
+
+class JWTTest extends TestCase
+{
+    use HasAuthentication;
+
+    public function test_jwt_payload_data()
+    {
+        $this->factory->create(Company::class, [
+            'email' => 'tony@starkindustries.com',
+            'password' => 'lovepepper',
+            'name' => 'Company Test',
+            'logo' => 'logo.png'
+        ]);
+
+        ['data' => $data] = $this->authenticate([
+            'username' => 'tony@starkindustries.com',
+            'password' => 'lovepepper',
+        ]);
+
+        $this->assertIsInt($data['id']);
+        $this->assertEquals('tony@starkindustries.com', $data['email']);
+        $this->assertEquals('Company Test', $data['name']);
+        $this->assertEquals('logo.png', $data['logo']);
+    }
+}

--- a/tests/Support/HasAuthentication.php
+++ b/tests/Support/HasAuthentication.php
@@ -9,7 +9,7 @@ use App\Repository\CompanyRepository;
 
 trait HasAuthentication
 {
-    protected function authenticate(array $credentials): void
+    protected function authenticate(array $credentials): array
     {
         if (! method_exists($this, 'createHttpClient')) {
             throw new RuntimeException('Cannot use HasAuthentication out of App\Tests\TestCase.');
@@ -18,5 +18,7 @@ trait HasAuthentication
         $this->client->request('POST', '/api/login/check', [], [], [], json_encode($credentials));
         $responseBody = json_decode($this->client->getResponse()->getContent(), true);
         $this->client->setServerParameter('HTTP_Authorization', sprintf('Bearer %s', $responseBody['token']));
+
+        return $responseBody;
     }
 }


### PR DESCRIPTION
Issue #109

Doc: https://github.com/lexik/LexikJWTAuthenticationBundle/blob/master/Resources/doc/2-data-customization.md#eventsauthentication_success---adding-public-data-to-the-jwt-response

Added these data on jwt payload

```json
{
   "token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpYXQiOjE1ODAyNTQzNTQsImV4cCI6MTU4MTExODM1NCwicm9sZXMiOlsiUk9MRV9DT01QQU5ZIl0sInVzZXJuYW1lIjoidG9ueUBzdGFya2luZHVzdHJpZXMuY29tIn0.d4B170Tvw96pZEwjWPaEcl6Xj8zSXLHi8nFMmg9I98g-iS6WtxLmmlvhIgrTB2hWV4NbSyDKZ3ixQSHOZZPHqw",
   "data":{
      "id":244,
      "name":"Company Test",
      "email":"tony@starkindustries.com",
      "logo":"logo.png"
   }
}
```